### PR TITLE
Add backend validation annotations

### DIFF
--- a/src/main/java/org/example/thigki/dto/req/DichVuReq.java
+++ b/src/main/java/org/example/thigki/dto/req/DichVuReq.java
@@ -2,6 +2,8 @@ package org.example.thigki.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -10,6 +12,7 @@ import lombok.NonNull;
 @NoArgsConstructor
 public class DichVuReq {
     @NotBlank
+    @Pattern(regexp = "DV\\d{3}", message = "Mã DV phải có dạng DVxxx")
     private String maDV;
 
     @NotBlank
@@ -19,5 +22,6 @@ public class DichVuReq {
     private String donViTinh;
 
     @NotNull
+    @Positive(message = "Đơn giá phải là số dương")
     private Double donGia;
 }

--- a/src/main/java/org/example/thigki/dto/req/KhachHangReq.java
+++ b/src/main/java/org/example/thigki/dto/req/KhachHangReq.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class KhachHangReq {
     @NotBlank
+    @Pattern(regexp = "KH\\d{5}", message = "Mã KH phải có dạng KHxxxxx")
     private String maKH;
     @NotBlank
     private String tenKH;

--- a/src/main/java/org/example/thigki/dto/req/SuDungDichVuReq.java
+++ b/src/main/java/org/example/thigki/dto/req/SuDungDichVuReq.java
@@ -1,17 +1,34 @@
 package org.example.thigki.dto.req;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
 
 @Data
 @NoArgsConstructor
 public class SuDungDichVuReq {
+    @NotBlank
+    @Pattern(regexp = "KH\\d{5}", message = "Mã KH phải có dạng KHxxxxx")
     private String maKH;
+
+    @NotBlank
+    @Pattern(regexp = "DV\\d{3}", message = "Mã DV phải có dạng DVxxx")
     private String maDV;
+
+    @NotBlank
+    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}",
+            message = "Ngày sử dụng phải có dạng yyyy-MM-dd")
     private String ngaySuDung;
+
+    @NotBlank
+    @Pattern(regexp = "([01]\\d|2[0-3]):[0-5]\\d",
+            message = "Giờ sử dụng phải có dạng HH:mm")
     private String gioSuDung;
+
+    @NotNull
+    @Positive(message = "Số lượng phải là số dương")
     private Integer soLuong;
 }

--- a/src/main/java/org/example/thigki/dto/req/SuDungMayReq.java
+++ b/src/main/java/org/example/thigki/dto/req/SuDungMayReq.java
@@ -1,14 +1,33 @@
 package org.example.thigki.dto.req;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 public class SuDungMayReq {
+    @NotBlank
+    @Pattern(regexp = "KH\\d{5}", message = "Mã KH phải có dạng KHxxxxx")
     private String maKH;
+
+    @NotBlank
     private String maMay;
-    private String ngayBatDauSuDung; // dùng String hoặc LocalDate, frontend sẽ gửi yyyy-MM-dd
-    private String gioBatDauSuDung;  // dùng String hoặc LocalTime, frontend sẽ gửi HH:mm
+
+    @NotBlank
+    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}",
+            message = "Ngày bắt đầu phải có dạng yyyy-MM-dd")
+    private String ngayBatDauSuDung; // frontend gửi yyyy-MM-dd
+
+    @NotBlank
+    @Pattern(regexp = "([01]\\d|2[0-3]):[0-5]\\d",
+            message = "Giờ bắt đầu phải có dạng HH:mm")
+    private String gioBatDauSuDung;  // frontend gửi HH:mm
+
+    @NotNull
+    @Positive(message = "Thời gian sử dụng phải là số dương")
     private Integer thoiGianSuDung;
 }


### PR DESCRIPTION
## Summary
- enforce format for `maKH` in `KhachHangReq`
- validate `maDV` and positive `donGia` in `DichVuReq`
- add validation rules for `SuDungDichVuReq` fields
- add validation rules for `SuDungMayReq` fields

## Testing
- `./mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68464ecb44148327af9ba163e980d120